### PR TITLE
updating the profile form and windows deploy bat file

### DIFF
--- a/users/views/profileFormviews.py
+++ b/users/views/profileFormviews.py
@@ -108,7 +108,7 @@ def newProfileForm(request):
   putSchoolFieldInContext(profile, context)
   putTalmzaFieldInContext(profile, context)
   putBirthdateFieldInContext(profile, context)
-  canAccessTalmzaFields(request, profile, context)
+  canAccessTalmzaFields(request, context)
   return render(request, 'users/profileForm.html', context)
 
 
@@ -182,16 +182,16 @@ def updateProfileForm(request):
   putSchoolFieldInContext(profile, context)
   putTalmzaFieldInContext(profile, context)
   putBirthdateFieldInContext(profile, context)
-  canAccessTalmzaFields(request, profile, context)
+  canAccessTalmzaFields(request, context)
   return render(request, 'users/profileForm.html', context)
 
 # check if the user can access the talmaza section in the profile form
 
 
-def canAccessTalmzaFields(request, profile, context):
+def canAccessTalmzaFields(request, context):
   # check if the user can access the talmaza section in the profile form
-  condition = (profile != None and request.profile.hasPermission('change_profile_talmza_level')) or (
-      profile != None and (request.profile.hasPermission('add_profile_talmza_level')))
+  condition = request.profile.hasPermission(
+      'change_profile_talmza_level') or request.profile.hasPermission('add_profile_talmza_level')
   context["canAccessTalmazaSection"] = condition
 
 

--- a/utils/batScripts/deploy.bat
+++ b/utils/batScripts/deploy.bat
@@ -34,6 +34,13 @@ popd
 start /B "" "%nginx_exe%"
 popd
 
+:: create these folder if they don't exsit
+mkdir "%nginx_folder%\temp\uwsgi_temp" 2>nul
+mkdir "%nginx_folder%\temp\scgi_temp" 2>nul
+mkdir "%nginx_folder%\temp\proxy_temp" 2>nul
+mkdir "%nginx_folder%\temp\fastcgi_temp" 2>nul
+mkdir "%nginx_folder%\temp\client_body_temp" 2>nul
+
 :: run waitress
 echo Starting waitress...
 start /B "" python .\utils\batScripts\waitress_config.py


### PR DESCRIPTION
1. there was a problem with the function called canAccessTalmzaFields, as it takes an argument called profile that in case of having an empty profile form it actually is equal to none that cause logical error for the predicted behaviour of a function
2. because the temp files in the nginx is empty, they don't get commited to github. in this case they become missing from the nginx folder which cause the nginx to throw errors. so i added to the bat file to create these folders if they don't exist